### PR TITLE
fix: use local base directory for codegen

### DIFF
--- a/apps/c_codegen/codegen.py
+++ b/apps/c_codegen/codegen.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 # ==============================
 # 환경설정
 # ==============================
-BASE_DIR = Path(__file__).resolve().parent.parent.parent
+BASE_DIR = Path(__file__).resolve().parent
 CONFIG_DIR = BASE_DIR / "configs"
 SYSTEM_PROMPT_PATH = BASE_DIR / "system_prompt.txt"
 


### PR DESCRIPTION
## Summary
- point BASE_DIR to codegen module directory

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2bfe97c98832e899716e51cc92138